### PR TITLE
fix(DiscordKeys): stickers is now sticker_items

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1481,7 +1481,7 @@ export const DiscordKeys = Object.freeze({
   STARTED: 'started',
   STATE: 'state',
   STATUS: 'status',
-  STICKERS: 'stickers',
+  STICKERS: 'sticker_items',
   STOPPED: 'stopped',
   STORE_APPLICATION_STATE: 'store_application_state',
   STORE_LISTING: 'store_listing',


### PR DESCRIPTION
as per https://github.com/discord/discord-api-docs/pull/3127 `stickers` on the Message object has been renamed to `sticker_items` and `stickers` itself is deprecated.